### PR TITLE
Add progress bar for post-file command

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ pipx install --force git+https://openshift-scale/data-server-cli.git
 
 ## Example
 
-Usage is automatically documented by [Typer](https://typer.tiangolo.com/). 
+Usage is automatically documented by [Typer](https://typer.tiangolo.com/).
 
 ### Post a file
 
@@ -48,11 +48,12 @@ Arguments:
 Options:
   --url TEXT      [env var: DATA_SERVER_URL; default: http://localhost:7070]
   --filedir TEXT  [env var: SNAPPY_FILE_DIR; default: ]
+  -s, --silent    [default: False]
   --help          Show this message and exit.
 ```
 
 Snappy's default root storage directory is called `data_server`. You can create a
-subdirectory within Snappy's storage directory by using the `--filedir` option, 
+subdirectory within Snappy's storage directory by using the `--filedir` option,
 or the `SNAPPY_FILE_DIR` environment variable.
 
 
@@ -126,6 +127,9 @@ Password:
 ```shell
 $ snappy post-file ./hat.jpg
 ```
+
+Will display a progress bar that shows approximate upload progress. Disable the
+progress bar with ``-s/--silent``.
 
 ### When you're done
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -194,6 +194,19 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
+name = "tqdm"
+version = "4.61.0"
+description = "Fast, Extensible Progress Meter"
+category = "main"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
+
+[package.extras]
+dev = ["py-make (>=0.1.0)", "twine", "wheel"]
+notebook = ["ipywidgets (>=6)"]
+telegram = ["requests"]
+
+[[package]]
 name = "typer"
 version = "0.3.2"
 description = "Typer, build great CLIs. Easy to code. Based on Python type hints."
@@ -215,7 +228,7 @@ doc = ["mkdocs (>=1.1.2,<2.0.0)", "mkdocs-material (>=5.4.0,<6.0.0)", "markdown-
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7.1"
-content-hash = "9d4631a35a68b7169cfb781c0d22380240a11143f78fc59f02b4cda52d77e757"
+content-hash = "293ae8d7857b8cf32d7de5bf5e8a8519753d0a80042fd14c7a20999c915dd0fc"
 
 [metadata.files]
 aiofiles = [
@@ -324,6 +337,10 @@ sniffio = [
 ]
 toolz = [
     {file = "toolz-0.10.0.tar.gz", hash = "sha256:08fdd5ef7c96480ad11c12d472de21acd32359996f69a5259299b540feba4560"},
+]
+tqdm = [
+    {file = "tqdm-4.61.0-py2.py3-none-any.whl", hash = "sha256:736524215c690621b06fc89d0310a49822d75e599fcd0feb7cc742b98d692493"},
+    {file = "tqdm-4.61.0.tar.gz", hash = "sha256:cd5791b5d7c3f2f1819efc81d36eb719a38e0906a7380365c556779f585ea042"},
 ]
 typer = [
     {file = "typer-0.3.2-py3-none-any.whl", hash = "sha256:ba58b920ce851b12a2d790143009fa00ac1d05b3ff3257061ff69dbdfc3d161b"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ toolz = "^0.10.0"
 typer = {extras = ["all"], version = "^0.3.1"}
 httpx = "^0.18.1"
 aiofiles = "^0.7.0"
+tqdm = "^4.61.0"
 
 [tool.poetry.dev-dependencies]
 pandas = "^1.2.4"

--- a/snappycli/client.py
+++ b/snappycli/client.py
@@ -1,14 +1,13 @@
 import sys
-import os
 
 from pathlib import Path
-from typing import (AsyncGenerator, BinaryIO)
+from typing import (AsyncGenerator)
 
-from toolz import pipe
-import httpx
 import aiofiles
-import asyncio
+import httpx
 
+from aiofiles import os as aios
+from toolz import pipe
 from tqdm import tqdm
 
 
@@ -36,50 +35,43 @@ def token(url: str, username: str, password: str) -> str:
     )
 
 
-async def _tell_aiofile(file: BinaryIO) -> int:
-    # with asyncio, file.tell() returns generator containing a future
-    done, pending = await asyncio.wait({next(file.tell())})
-    return int(done.pop().result())
-
-
-async def _get_file_size(file: BinaryIO) -> int:
-    current_pointer = await _tell_aiofile(file)
-    await file.seek(0, os.SEEK_END)
-    size = await _tell_aiofile(file)
-    await file.seek(current_pointer, os.SEEK_SET)
-
-    return size
-
-
-async def upload_bytes(
-    file: BinaryIO, chunk_size: int = 262_144_000
+async def up_bytes(            
+    filepath: Path,
+    chunk_size: int = 524_288_000
 ) -> AsyncGenerator[bytes, None]:
-    # 250 MiB == 250 * 1024 * 1024 == 262_144_000
+    # 500 MiB == 500 * 1024 * 1024 == 524,288,000
     contents = 'dummy'
     pointer = 0
-    file_size = await _get_file_size(file)
-
-    with tqdm(
-        total=file_size,
-        unit="B",
-        unit_scale=True,
-        unit_divisor=1024,
-        file=sys.stdout,
-        desc=f'Posting {file.name}'
-    ) as progress:
+    async with aiofiles.open(filepath, 'rb') as file:
         while len(contents):
             await file.seek(pointer)
             pointer += chunk_size
             contents = await file.read(chunk_size)
-            progress.update(float(chunk_size))
             yield contents
 
 
+
+async def show_progress_bar(filepath: Path) -> AsyncGenerator[bytes, None]:
+    file_stat = await aios.stat(filepath)
+    with tqdm(
+        total=file_stat.st_size,
+        unit="B",
+        unit_scale=True,
+        unit_divisor=1024,
+        file=sys.stdout,
+        desc=f'Posting {filepath.name}'
+    ) as progress:
+        async for contents in up_bytes(filepath):
+            progress.update(float(len(contents)))
+            yield contents            
+
+
 async def _async_post_file(
-    url: str, tkn: str, filepath: Path, filedir: str = ''
+    url: str, tkn: str, filepath: Path, filedir: str = '', 
+    silent: bool = False
 ) -> httpx.Response:
-    async with aiofiles.open(filepath, 'rb') as file, \
-            httpx.AsyncClient(timeout=httpx.Timeout(
+    
+    async with httpx.AsyncClient(timeout=httpx.Timeout(
                 write=None, read=None, connect=None, pool=None)) as client:
         r = await client.post(
             url,
@@ -87,7 +79,8 @@ async def _async_post_file(
                 'filename': filepath.name,
                 'filedir' : filedir
             },
-            data=upload_bytes(file),
+            data=up_bytes(filepath) if silent \
+              else show_progress_bar(filepath),
             headers={
                 'Authorization': f'Bearer {tkn}'
             }
@@ -96,10 +89,10 @@ async def _async_post_file(
 
 
 async def async_post_file(
-    url: str, tkn: str, filepath: Path, filedir: str = ''
+    url: str, tkn: str, filepath: Path, filedir: str = '', silent: bool = False
 ) -> str:
     return pipe(
-        await _async_post_file(url, tkn, filepath, filedir),
+        await _async_post_file(url, tkn, filepath, filedir, silent),
         response_handler,
         lambda r: r['loc']
     )

--- a/snappycli/client.py
+++ b/snappycli/client.py
@@ -37,6 +37,8 @@ def token(url: str, username: str, password: str) -> str:
 
 
 async def _tell_aiofile(file: BinaryIO) -> int:
+    # with asyncio, file.tell() returns generator containing a
+    # future
     done, pending = await asyncio.wait({next(file.tell())})
     return int(done.pop().result())
 

--- a/snappycli/client.py
+++ b/snappycli/client.py
@@ -37,8 +37,7 @@ def token(url: str, username: str, password: str) -> str:
 
 
 async def _tell_aiofile(file: BinaryIO) -> int:
-    # with asyncio, file.tell() returns generator containing a
-    # future
+    # with asyncio, file.tell() returns generator containing a future
     done, pending = await asyncio.wait({next(file.tell())})
     return int(done.pop().result())
 
@@ -56,7 +55,7 @@ async def upload_bytes(
     file: BinaryIO, chunk_size: int = 262_144_000
 ) -> AsyncGenerator[bytes, None]:
     # 250 MiB == 250 * 1024 * 1024 == 262_144_000
-    contents = "dummy"
+    contents = 'dummy'
     pointer = 0
     file_size = await _get_file_size(file)
 

--- a/snappycli/main.py
+++ b/snappycli/main.py
@@ -113,7 +113,7 @@ def post_file(
         '',
         envvar='SNAPPY_FILE_DIR'
     ),
-    silent: bool = typer.Option(False, "-s")
+    silent: bool = typer.Option(False, "-s", "--silent")
 ) -> None:
     typer.echo(f"""you're file is at {
     asyncio.run(_async_post_file(

--- a/snappycli/main.py
+++ b/snappycli/main.py
@@ -26,10 +26,11 @@ def exception_handler(func) -> Callable:
 
 @exception_handler
 async def _async_post_file(
-    url: str, token: str, filepath: Path, filedir: str
+    url: str, token: str, filepath: Path, filedir: str, silent: bool
 ) -> str:
     return await client.async_post_file(
-        url=url, tkn=token, filepath=filepath, filedir=filedir
+        url=url, tkn=token, filepath=filepath, filedir=filedir,
+        silent=silent
     )
 
 
@@ -99,14 +100,16 @@ def post_file(
     filedir: str = typer.Option(
         '',
         envvar='SNAPPY_FILE_DIR'
-    )
+    ),
+    silent: bool = typer.Option(False, "-s")
 ) -> None:
     typer.echo(f"""you're file is at {
     asyncio.run(_async_post_file(
         url=f'{url}/api',
         token=auth.token(auth.load()),
         filepath=filepath,
-        filedir=filedir))
+        filedir=filedir,
+        silent=silent))
     }""")
 
 

--- a/snappycli/main.py
+++ b/snappycli/main.py
@@ -115,7 +115,7 @@ def post_file(
     ),
     silent: bool = typer.Option(False, "-s", "--silent")
 ) -> None:
-    typer.echo(f"""you're file is at {
+    typer.echo(f"""your file is at {
     asyncio.run(_async_post_file(
         url=f'{url}/api',
         token=auth.token(auth.load()),

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -19,8 +19,9 @@ async def main():
                 os.getenv('DATA_SERVER_USERNAME'),
                 os.getenv('DATA_SERVER_PASSWORD'))
     await async_post_file(
-        f'{url}/stream', tkn,
-        Path('/home/mleader/5M.txt')
+        f'{url}/api', tkn,
+        Path('/home/mleader/1G.txt'),
+        '', True
     )
 
 


### PR DESCRIPTION
### Description

Adds a [tqdm](https://github.com/tqdm/tqdm) progress bar for the post-file command. Essentially works as follows:

1. Get the size of the file that the user wants to upload
2. Create the progress bar, with 100% set to the file size
3. As a chunk is read, before yielding it so it can be sent to the snappy server, update the progress bar with the chunk size

Acts as a really simple way to get a progress bar without needed to reformat how the upload happens. Should be fairly accurate- it won't be 100% accurate, but should be good enough for a verbose output to the user.
