### PR TITLE
Restore Apache License to its unmodified original

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2021 Matthew Franklin Leader
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
Please see: https://github.com/kubernetes/kubernetes/commit/d30db1f9a915aa95402e1190461469a1889d92be

Gist is that the appendix on the bottom should be left unmodified and only modified when that notice is added to individual files.