### PR TITLE
preprend http error details and bubble up http error to command line in…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "snappycli"
-version = "0.5.2"
+version = "0.5.3"
 description = "command line interface to a snappy data server client"
 authors = ["mleader <mleader@redhat.com>"]
 license = "Apache License 2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "snappycli"
-version = "0.5.3"
+version = "0.5.4"
 description = "command line interface to a snappy data server client"
 authors = ["mleader <mleader@redhat.com>"]
 license = "Apache License 2.0"

--- a/snappycli/client.py
+++ b/snappycli/client.py
@@ -12,7 +12,12 @@ from tqdm import tqdm
 
 
 def response_handler(r: httpx.Response) -> dict:
-    r.raise_for_status()
+    try:
+        r.raise_for_status()
+    except httpx.HTTPStatusError as e:
+        detail = r.json().get('detail', None)
+        cause = '\n'.join((detail,str(e))) if detail else str(e)
+        raise Exception(cause).with_traceback(e.__traceback__)
     return r.json()
 
 

--- a/snappycli/main.py
+++ b/snappycli/main.py
@@ -31,7 +31,7 @@ def exception_handler(fn: Callable) -> Callable:
             try:
                 return fn(*args, **kwargs)
             except Exception as e:
-                typer.echo(e)
+                typer.echo(e)                
                 raise typer.Abort()
         return wrapper
 
@@ -40,10 +40,11 @@ def exception_handler(fn: Callable) -> Callable:
 async def _async_post_file(
     url: str, token: str, filepath: Path, filedir: str, silent: bool
 ) -> str:
-    return await client.async_post_file(
+    r = await client.async_post_file(
         url=url, tkn=token, filepath=filepath, filedir=filedir,
         silent=silent
     )
+    return r
 
 
 @exception_handler


### PR DESCRIPTION
### Description

Provide greater clarity on a given http server error, by getting the HTTP error details from server's response, and concatenating them with the existing error message.

### Fixes

Obtuse error messages from the CLI client.